### PR TITLE
feat: build until 233 to support CLion Nova EAP

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginVersion = 0.3.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 223
-pluginUntilBuild = 232.*
+pluginUntilBuild = 233.*
 
 
 platformType = IU


### PR DESCRIPTION
Wanted to test this plugin against JetBrains' new version of CLion using a different engine, which is free for now, but the plugin doesn't allow installing it on that IDE yet.

I have no prior experience building IDE plugins, but from what I can tell this should be able to fix the issue.

<img width="432" alt="Screenshot 2023-11-20 at 16 29 55" src="https://github.com/MarioAriasC/zig-support/assets/1248467/f59e7503-2f5b-4017-b1bc-aa27c495d0ff">
